### PR TITLE
Add data properties search support

### DIFF
--- a/src/main/java/edu/uams/dbmi/protege/plugin/mireot/search/AdditionalOntologySearcher.java
+++ b/src/main/java/edu/uams/dbmi/protege/plugin/mireot/search/AdditionalOntologySearcher.java
@@ -4,18 +4,19 @@ import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.*;
 import org.semanticweb.owlapi.search.EntitySearcher;
 import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
+import org.semanticweb.owlapi.vocab.SKOSVocabulary;
 
 import edu.uams.dbmi.protege.plugin.mireot.search.result.ClassSearchResult;
 import edu.uams.dbmi.protege.plugin.mireot.search.result.ObjectPropertySearchResult;
 import edu.uams.dbmi.protege.plugin.mireot.search.result.SearchResult;
 import edu.uams.dbmi.protege.plugin.mireot.search.result.table.ResultTableCellRenderer;
 
-
 import java.awt.Component;
 import java.awt.EventQueue;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
 import java.util.*;
 
 import javax.swing.JOptionPane;
@@ -26,10 +27,10 @@ import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 
 /**
- * Searcher which loads an ontology and searches it 
- * by label, comment, and definition for matching classes or object properties
+ * Searcher which loads an ontology and searches it by label, comment, and
+ * definition for matching classes or object properties
  * 
- * @author Cheng Chen, Josh Hanna
+ * @author Cheng Chen, Josh Hanna, Zakariae Aloulen
  */
 public class AdditionalOntologySearcher {
 
@@ -47,6 +48,13 @@ public class AdditionalOntologySearcher {
 	private boolean searchByComment = true;
 	private boolean searchByDefinition = false;
 
+	/*
+	 * Add SKOS checkbox variables By Zakariae Aloulen
+	 */
+	private boolean searchBySKOSLabel = false;
+	private boolean searchBySKOSAltLabels = false;
+	private boolean searchBySKOSDefinition = false;
+
 	private boolean searchClasses = true;
 	private boolean searchObjectProperties = false;
 
@@ -61,7 +69,8 @@ public class AdditionalOntologySearcher {
 	 */
 
 	/**
-	 * Builds searcher using ontology located at @param url and prepares @param query 
+	 * Builds searcher using ontology located at @param url and prepares @param
+	 * query
 	 * 
 	 * @author Cheng Chen, Josh Hanna
 	 * @param String query
@@ -79,12 +88,9 @@ public class AdditionalOntologySearcher {
 	 * Accessors
 	 */
 
-
-
 	public void setQuery(String query) {
 		this.query = query;
 	}
-
 
 	public boolean searchByLabelFlag() {
 		return searchByLabel;
@@ -112,6 +118,39 @@ public class AdditionalOntologySearcher {
 		this.searchByDefinition = searchByDefinition;
 		optionsChanged = true;
 	}
+	
+	/**
+	 * Add SKOS checkbox methods
+	 * 
+	 * @author Zakariae Aloulen
+	 */
+
+	public boolean searchBySKOSLabelFlag() {
+		return searchBySKOSLabel;
+	}
+
+	public void setSearchBySKOSLabelFlag(boolean searchBySKOSLabel) {
+		this.searchBySKOSLabel = searchBySKOSLabel;
+		optionsChanged = true;
+	}
+
+	public boolean searchBySKOSDefinitionFlag() {
+		return searchBySKOSDefinition;
+	}
+
+	public void setSearchBySKOSDefinitionFlag(boolean searchBySKOSDefinition) {
+		this.searchBySKOSDefinition = searchBySKOSDefinition;
+		optionsChanged = true;
+	}
+
+	public boolean searchBySKOSAltLabelsFlag() {
+		return searchBySKOSAltLabels;
+	}
+
+	public void setSearchBySKOSAltLabelsFlag(boolean searchBySKOSAltLabels) {
+		this.searchBySKOSAltLabels = searchBySKOSAltLabels;
+		optionsChanged = true;
+	}
 
 	public boolean searchClassesFlag() {
 		return searchClasses;
@@ -135,7 +174,6 @@ public class AdditionalOntologySearcher {
 		this.ontUrl = ontUrl;
 	}
 
-
 	public OWLOntologyManager getAdditionalManager() {
 		return this.man;
 	}
@@ -148,13 +186,13 @@ public class AdditionalOntologySearcher {
 		return this.ontology;
 	}
 
-	public ArrayList<SearchResult> getResults(){
-		synchronized(results){
+	public ArrayList<SearchResult> getResults() {
+		synchronized (results) {
 			return this.results;
 		}
 	}
 
-	public void setFile(File ontFile){
+	public void setFile(File ontFile) {
 		this.ontFile = ontFile;
 	}
 
@@ -162,30 +200,29 @@ public class AdditionalOntologySearcher {
 	 * Loads ontology using URI passed in earlier
 	 * 
 	 * @author Josh Hanna
-	 * @throws IOException 
-	 * @throws OWLOntologyCreationException 
-	 * @throws Exception 
+	 * @throws IOException
+	 * @throws OWLOntologyCreationException
+	 * @throws Exception
 	 */
 	private void loadOntology() throws IOException, OWLOntologyCreationException {
 
+		if (this.ontUrl != null && this.oldOntUrl != null) {
 
-		if(this.ontUrl != null && this.oldOntUrl != null){
-
-			if(this.ontUrl.equals(oldOntUrl)){
-				//same ontology, no need to reload
+			if (this.ontUrl.equals(oldOntUrl)) {
+				// same ontology, no need to reload
 				return;
 			} else {
-				//keeping track of old url
+				// keeping track of old url
 				this.oldOntUrl = this.ontUrl;
 			}
 
 		} else {
-			//keeping track of old url
+			// keeping track of old url
 			this.oldOntUrl = this.ontUrl;
-		} 
+		}
 
-		if(this.ontFile != null && this.oldOntFile != null){
-			if(this.ontFile.equals(oldOntFile)){
+		if (this.ontFile != null && this.oldOntFile != null) {
+			if (this.ontFile.equals(oldOntFile)) {
 
 				return;
 			} else {
@@ -199,16 +236,16 @@ public class AdditionalOntologySearcher {
 
 		try {
 
-			if(ontUrl == null && ontFile == null){
+			if (ontUrl == null && ontFile == null) {
 				throw new IOException("Either ontology file or URL must exist.");
-			} else if(ontUrl != null){ 
+			} else if (ontUrl != null) {
 				this.ontology = man.loadOntology(IRI.create(ontUrl));
-			} else if(ontFile != null){
-				
+			} else if (ontFile != null) {
+
 				this.ontology = man.loadOntologyFromOntologyDocument(ontFile);
-				
+
 			}
-			
+
 		} catch (OWLOntologyCreationException e) {
 			JOptionPane.showMessageDialog(null, "Could not load ontology: " + e.getMessage());
 
@@ -223,10 +260,6 @@ public class AdditionalOntologySearcher {
 
 		this.man = man;
 
-
-
-
-
 	}
 
 	/*
@@ -237,28 +270,27 @@ public class AdditionalOntologySearcher {
 	 * Loads and then searches ontology based on options
 	 * 
 	 * @author Josh Hanna
-	 * @return ArrayList of SearchResult that represents matching Object Properties and/or Classes (depending on options)
-	 * @throws IOException 
-	 * @throws OWLOntologyCreationException 
-	 * @throws Exception 
+	 * @return ArrayList of SearchResult that represents matching Object Properties
+	 *         and/or Classes (depending on options)
+	 * @throws IOException
+	 * @throws OWLOntologyCreationException
+	 * @throws Exception
 	 */
 	public void search() throws OWLOntologyCreationException, IOException {
 
 		results.clear();
-		synchronized(results){
+		synchronized (results) {
 
 			loadOntology();
 
-
-			if(this.searchClassesFlag()){
+			if (this.searchClassesFlag()) {
 				results.addAll(this.searchByClass());
 			}
 
-			if(this.searchObjectPropertiesFlag()){
+			if (this.searchObjectPropertiesFlag()) {
 				results.addAll(this.searchByObjectProperty());
 			}
 
-			
 			results = this.removeDuplicates(results);
 		}
 
@@ -267,14 +299,13 @@ public class AdditionalOntologySearcher {
 	private ArrayList<SearchResult> removeDuplicates(ArrayList<SearchResult> results) {
 		ArrayList<SearchResult> searchList = new ArrayList<SearchResult>(results);
 		ArrayList<SearchResult> processed = new ArrayList<SearchResult>();
-		for(SearchResult result1 : searchList){
+		for (SearchResult result1 : searchList) {
 
-			for(SearchResult result2 : searchList){
-				if(!processed.contains(result2)){
-					if(!result1.equals(result2)){
+			for (SearchResult result2 : searchList) {
+				if (!processed.contains(result2)) {
+					if (!result1.equals(result2)) {
 
-
-						if(result1.getIRI().toString().equalsIgnoreCase(result2.getIRI().toString())){
+						if (result1.getIRI().toString().equalsIgnoreCase(result2.getIRI().toString())) {
 
 							results.remove(result2);
 						}
@@ -288,47 +319,65 @@ public class AdditionalOntologySearcher {
 	}
 
 	/**
+	 * Search classes using RDFS annotations (label, comment, definition) and/or SKOS
+	 * annotations (prefLabel, definition, altLabels)
 	 * 
-	 * @author Josh Hanna
+	 * @author Josh Hanna, Zakariae Aloulen
 	 * @return ArrayList<SearchResult> representing all matching Object Properties
 	 */
-	public ArrayList<SearchResult> searchByObjectProperty(){
+	public ArrayList<SearchResult> searchByObjectProperty() {
 		OWLDataFactory df = getAdditionalFactory();
 		String lowerCaseQuery = query.toLowerCase();
 
 		ArrayList<SearchResult> resultList = new ArrayList<SearchResult>();
 
-		OWLAnnotationProperty label = df.getOWLAnnotationProperty(OWLRDFVocabulary.RDFS_LABEL.getIRI());		
-		OWLAnnotationProperty comment = df.getOWLAnnotationProperty(OWLRDFVocabulary.RDFS_COMMENT.getIRI());		
-		OWLAnnotationProperty definition = df.getOWLAnnotationProperty(IRI
-				.create("http://purl.obolibrary.org/obo/IAO_0000115"));
+		OWLAnnotationProperty label = df.getOWLAnnotationProperty(OWLRDFVocabulary.RDFS_LABEL.getIRI());
+		OWLAnnotationProperty comment = df.getOWLAnnotationProperty(OWLRDFVocabulary.RDFS_COMMENT.getIRI());
+		OWLAnnotationProperty definition = df
+				.getOWLAnnotationProperty(IRI.create(URI.create("http://purl.obolibrary.org/obo/IAO_0000115")));
+
+		// Get SKOS Annotations URIs
+		OWLAnnotationProperty labelSkos = df.getOWLAnnotationProperty(SKOSVocabulary.PREFLABEL.getIRI());
+		OWLAnnotationProperty definitionSkos = df.getOWLAnnotationProperty(SKOSVocabulary.DEFINITION.getIRI());
+		OWLAnnotationProperty altLabelSkos = df.getOWLAnnotationProperty(SKOSVocabulary.ALTLABEL.getIRI());
 
 		if (this.searchByLabelFlag()) {
-
 			resultList.addAll(searchObjectProperties(lowerCaseQuery, label));
-
 		}
 
 		if (this.searchByDefinitionFlag()) {
-
 			resultList.addAll(searchObjectProperties(lowerCaseQuery, definition));
-
 		}
 
 		if (this.searchByCommentFlag()) {
-
 			resultList.addAll(searchObjectProperties(lowerCaseQuery, comment));
-
 		}
 
+		// Search by SKOS Annotations
+
+		// Skos Label
+		if (this.searchBySKOSLabelFlag()) {
+			resultList.addAll(searchObjectProperties(lowerCaseQuery, labelSkos));
+		}
+
+		// Skos altLabels
+		if (this.searchBySKOSAltLabelsFlag()) {
+			resultList.addAll(searchObjectProperties(lowerCaseQuery, altLabelSkos));
+		}
+
+		// Skos Definition
+		if (this.searchBySKOSDefinitionFlag()) {
+			resultList.addAll(searchObjectProperties(lowerCaseQuery, definitionSkos));
+		}
 
 		return resultList;
 	}
 
 	/**
 	 * 
-	 * @author Josh Hanna
+	 * @author Josh Hanna, Zakariae Aloulen
 	 * @return ArrayList<SearchResult> representing all matching Classes
+	 * 
 	 */
 	public ArrayList<SearchResult> searchByClass() {
 
@@ -338,38 +387,42 @@ public class AdditionalOntologySearcher {
 
 		ArrayList<SearchResult> resultList = new ArrayList<SearchResult>();
 
-
 		OWLAnnotationProperty label = df.getOWLAnnotationProperty(OWLRDFVocabulary.RDFS_LABEL.getIRI());
-
-
 		OWLAnnotationProperty comment = df.getOWLAnnotationProperty(OWLRDFVocabulary.RDFS_COMMENT.getIRI());
-		
-		OWLAnnotationProperty definition = df.getOWLAnnotationProperty(IRI.create("http://purl.obolibrary.org/obo/IAO_0000115"));
+		OWLAnnotationProperty definition = df
+				.getOWLAnnotationProperty(IRI.create("http://purl.obolibrary.org/obo/IAO_0000115"));
 
+		// Get SKOS Annotations URIs
+		OWLAnnotationProperty labelSkos = df.getOWLAnnotationProperty(SKOSVocabulary.PREFLABEL.getIRI());
+		OWLAnnotationProperty definitionSkos = df.getOWLAnnotationProperty(SKOSVocabulary.DEFINITION.getIRI());
+		OWLAnnotationProperty altLabelSkos = df.getOWLAnnotationProperty(SKOSVocabulary.ALTLABEL.getIRI());
 
 		if (this.searchByLabelFlag()) {
-
 			resultList.addAll(this.searchClasses(lowercaseQuery, label));
-			
-
 		}
 
 		if (this.searchByCommentFlag()) {
-			
-
 			resultList.addAll(this.searchClasses(lowercaseQuery, comment));
-
 		}
-
 
 		if (this.searchByDefinitionFlag()) {
-			
-
 			resultList.addAll(this.searchClasses(lowercaseQuery, definition));
-
 		}
-		
 
+		// Skos Label
+		if (this.searchBySKOSLabelFlag()) {
+			resultList.addAll(this.searchClasses(lowercaseQuery, labelSkos));
+		}
+
+		// Skos altLabels
+		if (this.searchBySKOSAltLabelsFlag()) {
+			resultList.addAll(this.searchClasses(lowercaseQuery, altLabelSkos));
+		}
+
+		// Skos Definition
+		if (this.searchBySKOSDefinitionFlag()) {
+			resultList.addAll(this.searchClasses(lowercaseQuery, definitionSkos));
+		}
 
 		return resultList;
 	}
@@ -379,32 +432,31 @@ public class AdditionalOntologySearcher {
 	 * @author Josh Hanna
 	 * @param query
 	 * @param annotationProperty
-	 * @return ArrayList<SearchResults> of any object properties that contain an annotation of type annotationProperty that matches query
+	 * @return ArrayList<SearchResults> of any object properties that contain an
+	 *         annotation of type annotationProperty that matches query
 	 */
 	private ArrayList<SearchResult> searchObjectProperties(String query, OWLAnnotationProperty annotationProperty) {
 
-		//list of ontology and imports
+		// list of ontology and imports
 		ArrayList<OWLOntology> ontologies = new ArrayList<OWLOntology>();
 
 		ontologies.add(ontology);
-		
+
 		Set<OWLOntology> imports = getAdditionalManager().getImports(ontology);
 
-		for(OWLOntology ont : imports){
+		for (OWLOntology ont : imports) {
 			ontologies.add(ont);
 		}
 
 		ArrayList<SearchResult> resultList = new ArrayList<SearchResult>();
 
-		for(OWLOntology ont : ontologies){
+		for (OWLOntology ont : ontologies) {
 			for (OWLObjectProperty objectProperty : ont.getObjectPropertiesInSignature()) {
-
 				// Get the annotations on the object property that use the annotation property
-				for (OWLAnnotation annotation : EntitySearcher.getAnnotations(objectProperty.getIRI(), ont, annotationProperty)) {
-
+				for (OWLAnnotation annotation : EntitySearcher.getAnnotations(objectProperty.getIRI(), ont,
+						annotationProperty)) {
 					if (annotation.getValue() instanceof OWLLiteral) {
 						OWLLiteral val2 = (OWLLiteral) annotation.getValue();
-
 						if (val2.getLiteral().toString().toLowerCase().contains(query)) {
 							IRI labelIri = objectProperty.getIRI();
 
@@ -413,8 +465,10 @@ public class AdditionalOntologySearcher {
 
 							String matchContext = val2.getLiteral();
 
-							SearchResult resultItem = new ObjectPropertySearchResult(labelIri, labelName, matchType, matchContext, objectProperty, ontology);
+							SearchResult resultItem = new ObjectPropertySearchResult(labelIri, labelName, matchType,
+									matchContext, objectProperty, ontology);
 							resultList.add(resultItem);
+
 						}
 					}
 				}
@@ -428,38 +482,34 @@ public class AdditionalOntologySearcher {
 	 * @author Josh Hanna
 	 * @param query
 	 * @param annotationProperty
-	 * @return ArrayList<SearchResults> of any classes that contain an annotation of type annotationProperty that matches query
+	 * @return ArrayList<SearchResults> of any classes that contain an annotation of
+	 *         type annotationProperty that matches query
 	 */
-	private ArrayList<SearchResult> searchClasses(String query, OWLAnnotationProperty annotationProperty){
-		
+	private ArrayList<SearchResult> searchClasses(String query, OWLAnnotationProperty annotationProperty) {
 
-		//list of ontology and imports
+		// list of ontology and imports
 		ArrayList<OWLOntology> ontologies = new ArrayList<OWLOntology>();
 		ontologies.add(ontology);
-		
-		Set<OWLOntology> imports = getAdditionalManager().getImports(ontology);
-		
 
-		for(OWLOntology ont : imports) {
+		Set<OWLOntology> imports = getAdditionalManager().getImports(ontology);
+
+		for (OWLOntology ont : imports) {
 			ontologies.add(ont);
 		}
-		
 
 		ArrayList<SearchResult> resultList = new ArrayList<SearchResult>();
 
-		for(OWLOntology ont : ontologies){
-			
-			for (OWLClass cls : ont.getClassesInSignature()) {
+		for (OWLOntology ont : ontologies) {
 
+			for (OWLClass cls : ont.getClassesInSignature()) {
 
 				// Get the annotations on the class that use the label property
 				for (OWLAnnotation annotation : EntitySearcher.getAnnotations(cls.getIRI(), ont, annotationProperty)) {
 
-
 					if (annotation.getValue() instanceof OWLLiteral) {
 						OWLLiteral val2 = (OWLLiteral) annotation.getValue();
-
 						if (val2.getLiteral().toString().toLowerCase().contains(query)) {
+
 							IRI labelIri = cls.getIRI();
 
 							String labelName = getLabel(cls, ont);
@@ -467,7 +517,8 @@ public class AdditionalOntologySearcher {
 
 							String matchContext = val2.getLiteral();
 
-							ClassSearchResult LabelResultList = new ClassSearchResult(labelIri, labelName, matchType, matchContext, cls, ontology);
+							ClassSearchResult LabelResultList = new ClassSearchResult(labelIri, labelName, matchType,
+									matchContext, cls, ontology);
 
 							resultList.add(LabelResultList);
 						}
@@ -481,40 +532,82 @@ public class AdditionalOntologySearcher {
 
 	/**
 	 * 
-	 * @author Josh Hanna
+	 * @author Josh Hanna, Zakariae Aloulen
 	 * @param entity
 	 * @param ontology
-	 * @return A String that represents the first english Label on an OWL Entity
+	 * @return A String that represents the first english Label (RDFS or SKOS) on an OWL Entity
 	 */
 	String getLabel(OWLEntity entity, OWLOntology ontology) {
 
 		OWLDataFactory df = getAdditionalFactory();
 
 		String label = "";
-		OWLAnnotationProperty labelProperty = df
-				.getOWLAnnotationProperty(OWLRDFVocabulary.RDFS_LABEL.getIRI());
+		OWLAnnotationProperty labelProperty = df.getOWLAnnotationProperty(OWLRDFVocabulary.RDFS_LABEL.getIRI());
 
-		// Get the annotations on the class that use the label property
-		for (OWLAnnotation annotation : EntitySearcher.getAnnotations(entity.getIRI(), ontology, labelProperty)) {
-			if (annotation.getValue() instanceof OWLLiteral) {
-				OWLLiteral val = (OWLLiteral) annotation.getValue();
-				if (val.hasLang("en") || !val.hasLang()) {
-					label = val.getLiteral().toString();
-				} else {
-					String ClassString = entity.getIRI().toString();
-					label = ClassString.substring(ClassString
-							.indexOf("#") + 1);
+		OWLAnnotationProperty labelPropertySKOS = df.getOWLAnnotationProperty(SKOSVocabulary.PREFLABEL.getIRI());
+
+		OWLAnnotationProperty altLabelPropertySKOS = df.getOWLAnnotationProperty(SKOSVocabulary.ALTLABEL.getIRI());
+
+		Collection<OWLAnnotation> annotations = EntitySearcher.getAnnotations(entity.getIRI(), ontology, labelProperty);
+		Collection<OWLAnnotation> annotationsSKOS = EntitySearcher.getAnnotations(entity.getIRI(), ontology,
+				labelPropertySKOS);
+		Collection<OWLAnnotation> annotationsSKOS2 = EntitySearcher.getAnnotations(entity.getIRI(), ontology,
+				altLabelPropertySKOS);
+
+		if (annotations.size() > 0)
+
+		{
+			for (OWLAnnotation annotation : EntitySearcher.getAnnotations(entity.getIRI(), ontology, labelProperty)) {
+				if (annotation.getValue() instanceof OWLLiteral) {
+					OWLLiteral val = (OWLLiteral) annotation.getValue();
+					if (val.hasLang("en") || !val.hasLang()) {
+						label = val.getLiteral().toString();
+					} else {
+						String ClassString = entity.getIRI().toString();
+						label = ClassString.substring(ClassString.indexOf("#") + 1);
+					}
 				}
 			}
 		}
+
+		else if (annotationsSKOS.size() > 0) {
+			for (OWLAnnotation annotation : EntitySearcher.getAnnotations(entity.getIRI(), ontology,
+					labelPropertySKOS)) {
+				if (annotation.getValue() instanceof OWLLiteral) {
+					OWLLiteral val = (OWLLiteral) annotation.getValue();
+					if (val.hasLang("en") || !val.hasLang()) {
+						label = val.getLiteral().toString();
+					} else {
+						String ClassString = entity.getIRI().toString();
+						label = ClassString.substring(ClassString.indexOf("#") + 1);
+					}
+				}
+			}
+		} else if (annotationsSKOS2.size() > 0) {
+			for (OWLAnnotation annotation : EntitySearcher.getAnnotations(entity.getIRI(), ontology,
+					altLabelPropertySKOS)) {
+				if (annotation.getValue() instanceof OWLLiteral) {
+					OWLLiteral val = (OWLLiteral) annotation.getValue();
+					if (val.hasLang("en") || !val.hasLang()) {
+						label = val.getLiteral().toString();
+					} else {
+						String ClassString = entity.getIRI().toString();
+						label = ClassString.substring(ClassString.indexOf("#") + 1);
+					}
+				}
+			}
+		}
+
+		// Get the annotations on the class that use the label property
+
 		return label;
 	}
 
-	public boolean isSameOntology(){
-		if(ontUrl != null && oldOntUrl != null && ontUrl.equals(oldOntUrl)){
+	public boolean isSameOntology() {
+		if (ontUrl != null && oldOntUrl != null && ontUrl.equals(oldOntUrl)) {
 			return true;
 		}
-		if(ontFile != null && oldOntFile != null && ontFile.equals(oldOntFile)){
+		if (ontFile != null && oldOntFile != null && ontFile.equals(oldOntFile)) {
 			return true;
 		}
 		return false;
@@ -523,9 +616,8 @@ public class AdditionalOntologySearcher {
 	public synchronized void buildResultTable(final String[] columnNames, final DefaultTableModel tableModel,
 			final JTable resultTable) {
 
-
-		//if it's the same search as last time, no need to do anything
-		if((!optionsChanged) && (this.query.equalsIgnoreCase(this.oldQuery) && this.isSameOntology())){
+		// if it's the same search as last time, no need to do anything
+		if ((!optionsChanged) && (this.query.equalsIgnoreCase(this.oldQuery) && this.isSameOntology())) {
 			return;
 		} else {
 
@@ -533,11 +625,9 @@ public class AdditionalOntologySearcher {
 			optionsChanged = false;
 
 			Thread t = new Thread() {
-				public void run(){
-
+				public void run() {
 
 					this.clearTableModel(tableModel);
-
 
 					setStatus("Starting search", tableModel);
 
@@ -546,11 +636,9 @@ public class AdditionalOntologySearcher {
 					} catch (Exception e) {
 						setStatus("Error", tableModel);
 						return;
-					} 
-					
+					}
 
 					ArrayList<SearchResult> resultList = getResults();
-
 
 					if (resultList.size() == 0) {
 						setStatus("No results", tableModel);
@@ -568,7 +656,7 @@ public class AdditionalOntologySearcher {
 					final Object[] header = new Object[1];
 					header[0] = "Status";
 
-					EventQueue.invokeLater(new Runnable(){
+					EventQueue.invokeLater(new Runnable() {
 
 						@Override
 						public void run() {
@@ -579,18 +667,17 @@ public class AdditionalOntologySearcher {
 
 				}
 
-				private void updateTable(final ArrayList<SearchResult> resultList,
-						final JTable resultTable, final DefaultTableModel tableModel, final String[] columnNames) {
+				private void updateTable(final ArrayList<SearchResult> resultList, final JTable resultTable,
+						final DefaultTableModel tableModel, final String[] columnNames) {
 
-					EventQueue.invokeLater(new Runnable(){
-
+					EventQueue.invokeLater(new Runnable() {
 
 						@Override
 						public void run() {
 
 							Object[][] resultData = new Object[resultList.size()][4];
 
-							//custom renderer for tooltips
+							// custom renderer for tooltips
 							ResultTableCellRenderer renderer = new ResultTableCellRenderer();
 
 							for (int i = 0; i < resultList.size(); i++) {
@@ -606,25 +693,21 @@ public class AdditionalOntologySearcher {
 
 							}
 
-							//setting custom renderer on matchType column for tooltip
+							// setting custom renderer on matchType column for tooltip
 							TableColumn col = resultTable.getColumnModel().getColumn(3);
 							col.setCellRenderer(renderer);
 							packColumns(resultTable, 5);
-
 
 						}
 					});
 				}
 
-
-
-
 				private void clearTableModel(final DefaultTableModel tableModel) {
 					try {
 
-						EventQueue.invokeAndWait(new Runnable(){
+						EventQueue.invokeAndWait(new Runnable() {
 
-							public void run(){
+							public void run() {
 
 								while (tableModel.getRowCount() > 0) {
 									tableModel.removeRow(tableModel.getRowCount() - 1);
@@ -642,16 +725,14 @@ public class AdditionalOntologySearcher {
 
 				}
 
-
-
 				private void packColumns(JTable table, int margin) {
-					for (int c=0; c<table.getColumnCount(); c++) {
+					for (int c = 0; c < table.getColumnCount(); c++) {
 						packColumn(table, c, 2);
-					} 
+					}
 				}
 
 				public void packColumn(JTable table, int vColIndex, int margin) {
-					DefaultTableColumnModel colModel = (DefaultTableColumnModel)table.getColumnModel();
+					DefaultTableColumnModel colModel = (DefaultTableColumnModel) table.getColumnModel();
 					TableColumn col = colModel.getColumn(vColIndex);
 					int width = 0;
 
@@ -660,24 +741,24 @@ public class AdditionalOntologySearcher {
 					if (renderer == null) {
 						renderer = table.getTableHeader().getDefaultRenderer();
 					}
-					Component comp = renderer.getTableCellRendererComponent(
-							table, col.getHeaderValue(), false, false, 0, 0);
+					Component comp = renderer.getTableCellRendererComponent(table, col.getHeaderValue(), false, false,
+							0, 0);
 					width = comp.getPreferredSize().width;
 
 					// Get maximum width of column data
-					for (int r=0; r<table.getRowCount(); r++) {
+					for (int r = 0; r < table.getRowCount(); r++) {
 						renderer = table.getCellRenderer(r, vColIndex);
-						comp = renderer.getTableCellRendererComponent(
-								table, table.getValueAt(r, vColIndex), false, false, r, vColIndex);
+						comp = renderer.getTableCellRendererComponent(table, table.getValueAt(r, vColIndex), false,
+								false, r, vColIndex);
 						width = Math.max(width, comp.getPreferredSize().width);
 					}
 
 					// Add margin
-					width += 2*margin;
+					width += 2 * margin;
 
 					// Set the width
 					col.setPreferredWidth(width);
-				}	
+				}
 
 			};
 

--- a/src/main/java/edu/uams/dbmi/protege/plugin/mireot/search/result/DatatypePropertySearchResult.java
+++ b/src/main/java/edu/uams/dbmi/protege/plugin/mireot/search/result/DatatypePropertySearchResult.java
@@ -1,0 +1,65 @@
+package edu.uams.dbmi.protege.plugin.mireot.search.result;
+
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLEntity;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLDataProperty;
+
+/**
+ * Represents a matching Datatype Property
+ * 
+ * @author Zakariae Aloulen
+ */
+public class DatatypePropertySearchResult implements SearchResult {
+	private String nameString;
+	private String matchType;
+	private String matchContext;
+	private IRI iri;
+	
+	private OWLOntology ontology;
+	private OWLDataProperty datatypeProperty;
+
+	public OWLEntity getOWLEntity() {
+		return datatypeProperty;
+	}
+
+	@Override
+	public String getType() {
+		return "Datatype Property";
+	}
+
+	@Override
+	public IRI getIRI() {
+		return iri;
+	}
+
+	@Override
+	public String getName() {
+		return nameString;
+	}
+
+	@Override
+	public String getMatchType() {
+		return matchType;
+	}
+
+	@Override
+	public OWLOntology getOntology() {
+		return ontology;
+	}
+	
+	public DatatypePropertySearchResult(IRI iri, String name, String matchType, String matchContext, OWLEntity datatypeProperty, OWLOntology ontology) {
+		this.iri = iri;
+		this.nameString = name;
+		this.matchType = matchType;
+		this.matchContext = matchContext;
+		this.datatypeProperty = (OWLDataProperty) datatypeProperty;
+		this.ontology = ontology;
+	}
+
+	@Override
+	public String getMatchContext() {
+		return matchContext;
+	}
+
+}

--- a/src/main/java/edu/uams/dbmi/protege/plugin/mireot/search/transferable/OWLDatatypePropertyTransferable.java
+++ b/src/main/java/edu/uams/dbmi/protege/plugin/mireot/search/transferable/OWLDatatypePropertyTransferable.java
@@ -1,0 +1,79 @@
+package edu.uams.dbmi.protege.plugin.mireot.search.transferable;
+
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.io.IOException;
+import java.io.Serializable;
+
+import org.semanticweb.owlapi.model.OWLDataProperty;
+import org.semanticweb.owlapi.model.OWLOntology;
+
+/**
+ * Transferable that transfers a message containing both an OWL Datatype Property and an Ontology used for drag and drop
+ * 
+ * @author Zakariae Aloulen
+ */
+public class OWLDatatypePropertyTransferable implements Transferable, Serializable {
+	
+	OWLDatatypePropertyMessage message;
+
+	private DataFlavor ontDataFlavor = new DataFlavor(OWLDataProperty.class, OWLDataProperty.class.getSimpleName());
+
+	public OWLDatatypePropertyTransferable(OWLDataProperty datatypeProperty,
+			OWLOntology ontology, String URL) {
+		this.message = new OWLDatatypePropertyMessage();
+		message.datatypeProperty = datatypeProperty;
+		message.ontology = ontology;
+		message.URL = URL;
+	}
+
+	@Override
+	public Object getTransferData(DataFlavor flavor)
+			throws UnsupportedFlavorException, IOException {
+		if(flavor.equals(ontDataFlavor)){
+			return this.message;
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public DataFlavor[] getTransferDataFlavors() {
+		return null;
+	}
+
+	@Override
+	public boolean isDataFlavorSupported(DataFlavor flavor) {
+		if(flavor.equals(ontDataFlavor)){
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Message representing data used for drag and drop.
+	 * Contains references to both ontology and datatype property.
+	 * 
+	 * @author Josh Hanna
+	 */
+	public class OWLDatatypePropertyMessage implements Serializable{
+		private OWLDataProperty datatypeProperty;
+		private OWLOntology ontology;
+		private String URL;
+		
+		public OWLDataProperty getDatatypeProperty() {
+			return datatypeProperty;
+		}
+
+		public OWLOntology getOntology() {
+			return ontology;
+		}
+		
+		public String getURL(){
+			return URL;
+		}
+		
+	}
+}

--- a/src/main/java/edu/uams/dbmi/protege/plugin/mireot/view/AdditionalOntologyView.java
+++ b/src/main/java/edu/uams/dbmi/protege/plugin/mireot/view/AdditionalOntologyView.java
@@ -31,14 +31,17 @@ import javax.swing.table.DefaultTableModel;
 import org.protege.editor.owl.model.event.OWLModelManagerListener;
 import org.protege.editor.owl.ui.view.AbstractOWLViewComponent;
 import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLDataProperty;
 import org.semanticweb.owlapi.model.OWLObjectProperty;
 
 import edu.uams.dbmi.protege.plugin.mireot.search.AdditionalOntologyList;
 import edu.uams.dbmi.protege.plugin.mireot.search.AdditionalOntologySearcher;
 import edu.uams.dbmi.protege.plugin.mireot.search.result.ClassSearchResult;
+import edu.uams.dbmi.protege.plugin.mireot.search.result.DatatypePropertySearchResult;
 import edu.uams.dbmi.protege.plugin.mireot.search.result.ObjectPropertySearchResult;
 import edu.uams.dbmi.protege.plugin.mireot.search.result.SearchResult;
 import edu.uams.dbmi.protege.plugin.mireot.search.transferable.OWLClassTransferable;
+import edu.uams.dbmi.protege.plugin.mireot.search.transferable.OWLDatatypePropertyTransferable;
 import edu.uams.dbmi.protege.plugin.mireot.search.transferable.OWLObjectPropertyTransferable;
 
 /**
@@ -63,6 +66,7 @@ public class AdditionalOntologyView extends AbstractOWLViewComponent {
 
 	private JCheckBox clsCheckBox;
 	private JCheckBox objPropCheckBox;
+	private JCheckBox dataTypePropCheckBox;
 
 	private JButton executeButton;
 	private OWLModelManagerListener listener;
@@ -269,6 +273,22 @@ public class AdditionalOntologyView extends AbstractOWLViewComponent {
 			}
 		});
 
+		
+		dataTypePropCheckBox = new JCheckBox(new AbstractAction("Datatype Property") {
+			/**
+			 *
+			 */
+			private static final long serialVersionUID = 1L;
+
+			public void actionPerformed(ActionEvent e) {
+				if (dataTypePropCheckBox.isSelected()) {
+					saoi.setSearchDataTypePropertiesFlag(true);
+				} else {
+					saoi.setSearchDataTypePropertiesFlag(false);
+				}
+			}
+		});
+		
 		// setting the class entity type as the default type to search for
 		clsCheckBox.setSelected(true);
 
@@ -276,6 +296,9 @@ public class AdditionalOntologyView extends AbstractOWLViewComponent {
 		searchBox.add(Box.createHorizontalStrut(1));
 
 		searchBox.add(objPropCheckBox);
+		searchBox.add(Box.createHorizontalStrut(1));
+		
+		searchBox.add(dataTypePropCheckBox);
 		searchBox.add(Box.createHorizontalStrut(1));
 
 		showSearchLabelCheckBox = new JCheckBox(new AbstractAction("Label") {
@@ -538,6 +561,13 @@ public class AdditionalOntologyView extends AbstractOWLViewComponent {
 
 				return new OWLObjectPropertyTransferable((OWLObjectProperty) objectPropertyTransferData.getOWLEntity(),
 						objectPropertyTransferData.getOntology(), ontologyURL);
+			}
+			
+			else if (transferData.getType().equals("Datatype Property")) {
+				DatatypePropertySearchResult datatypePropertyTransferData = (DatatypePropertySearchResult) transferData;
+
+				return new OWLDatatypePropertyTransferable((OWLDataProperty) datatypePropertyTransferData.getOWLEntity(),
+						datatypePropertyTransferData.getOntology(), ontologyURL);
 			}
 
 			return null;

--- a/src/main/java/edu/uams/dbmi/protege/plugin/mireot/view/AdditionalOntologyView.java
+++ b/src/main/java/edu/uams/dbmi/protege/plugin/mireot/view/AdditionalOntologyView.java
@@ -6,7 +6,6 @@ import java.awt.datatransfer.Transferable;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 
 import javax.swing.AbstractAction;
@@ -17,7 +16,6 @@ import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
-import javax.swing.JDialog;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -26,7 +24,6 @@ import javax.swing.JSplitPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
 import javax.swing.ListSelectionModel;
-import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
 import javax.swing.TransferHandler;
 import javax.swing.table.DefaultTableModel;
@@ -35,8 +32,6 @@ import org.protege.editor.owl.model.event.OWLModelManagerListener;
 import org.protege.editor.owl.ui.view.AbstractOWLViewComponent;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLObjectProperty;
-import org.semanticweb.owlapi.model.OWLOntologyCreationException;
-import org.semanticweb.owlapi.model.OWLOntologyStorageException;
 
 import edu.uams.dbmi.protege.plugin.mireot.search.AdditionalOntologyList;
 import edu.uams.dbmi.protege.plugin.mireot.search.AdditionalOntologySearcher;
@@ -46,475 +41,515 @@ import edu.uams.dbmi.protege.plugin.mireot.search.result.SearchResult;
 import edu.uams.dbmi.protege.plugin.mireot.search.transferable.OWLClassTransferable;
 import edu.uams.dbmi.protege.plugin.mireot.search.transferable.OWLObjectPropertyTransferable;
 
-
 /**
  * View which allows users to search and copy from an additional ontology
  *
- * @author Chen Cheng, Josh Hanna
+ * @author Chen Cheng, Josh Hanna, Zakariae Aloulen
+ * 
  */
 public class AdditionalOntologyView extends AbstractOWLViewComponent {
-    private static final long serialVersionUID = -4515710047558710080L;
+	private static final long serialVersionUID = -4515710047558710080L;
 
-    private JTextField searchBox;
-    private JCheckBox showSearchCommentCheckBox;
-    private JCheckBox showSearchLabelCheckBox;
-    private JCheckBox showSearchDefinitionCheckBox;
-    private JCheckBox clsCheckBox;
-    private JCheckBox objPropCheckBox;
+	private JTextField searchBox;
 
-    private JButton executeButton;
-    private OWLModelManagerListener listener;
-    private static AdditionalOntologyList ddla = new AdditionalOntologyList();
-    private String query;
-    private ArrayList<SearchResult> resultList;
-    private JTable resultTable;
-    private JScrollPane scrollPane;
-    private String[] columnNames = { "Entity Type", "Label", "URI", "Match Type" };
-    public AdditionalOntologySearcher saoi;
-    private DefaultTableModel tableModel = new DefaultTableModel();
-    private String ontologyURL = null;
-    private File ontoFile = null;
+	private JCheckBox showSearchCommentCheckBox;
+	private JCheckBox showSearchLabelCheckBox;
+	private JCheckBox showSearchDefinitionCheckBox;
+	
+	// Add SKOS Annotations check boxes
+	private JCheckBox showSearchLabelSKOSCheckBox;
+	private JCheckBox showSearchSKOSDefinitionCheckBox;
+	private JCheckBox showSearchSKOSAltLabelsCheckBox;
 
-    private JTextField currentOntologyBox;
+	private JCheckBox clsCheckBox;
+	private JCheckBox objPropCheckBox;
 
-    private JComboBox ontologySelectBox;
+	private JButton executeButton;
+	private OWLModelManagerListener listener;
+	private static AdditionalOntologyList ddla = new AdditionalOntologyList();
+	private String query;
+	private ArrayList<SearchResult> resultList;
+	private JTable resultTable;
+	private JScrollPane scrollPane;
+	private String[] columnNames = { "Entity Type", "Label", "URI", "Match Type" };
+	public AdditionalOntologySearcher saoi;
+	private DefaultTableModel tableModel = new DefaultTableModel();
+	private String ontologyURL = null;
+	private File ontoFile = null;
 
+	private JTextField currentOntologyBox;
 
+	private JComboBox ontologySelectBox;
 
+	public AdditionalOntologySearcher getSearcher() {
+		return saoi;
+	}
 
+	protected void initialiseOWLView() throws Exception {
+		setLayout(new BorderLayout(10, 10));
 
-    public AdditionalOntologySearcher getSearcher() {
-        return saoi;
-    }
+		JComponent queryPanel = this.createQueryPanel();
+		JComponent resultsPanel = this.createResultsPanel();
 
+		JSplitPane splitter = new JSplitPane(JSplitPane.VERTICAL_SPLIT, queryPanel, resultsPanel);
+		splitter.setDividerLocation(0.3);
+		add(splitter, BorderLayout.CENTER);
 
-    protected void initialiseOWLView() throws Exception {
-        setLayout(new BorderLayout(10, 10));
+		// setting up the searcher
+		this.saoi = new AdditionalOntologySearcher();
 
-        JComponent queryPanel = this.createQueryPanel();
-        JComponent resultsPanel = this.createResultsPanel();
+		// setting it so that tooltips last longer
+		// this will probably affect other tabs
+		ToolTipManager.sharedInstance().setDismissDelay(100000);
 
-        JSplitPane splitter = new JSplitPane(JSplitPane.VERTICAL_SPLIT,
-                queryPanel, resultsPanel);
-        splitter.setDividerLocation(0.3);
-        add(splitter, BorderLayout.CENTER);
+	}
 
-        //setting up the searcher
-        this.saoi = new AdditionalOntologySearcher();
+	private JComponent createQueryPanel() {
+		JComponent queryPanel = new JPanel(new BorderLayout());
 
-        //setting it so that tooltips last longer
-        //this will probably affect other tabs
-        ToolTipManager.sharedInstance().setDismissDelay(100000);
+		JComponent ontologySelectPanel = createOntologySelectBox();
+		JComponent searchPanel = createSearchPanel();
 
-    }
+		queryPanel.add(ontologySelectPanel, BorderLayout.NORTH);
+		queryPanel.add(searchPanel, BorderLayout.SOUTH);
 
-    private JComponent createQueryPanel(){
-        JComponent queryPanel = new JPanel(new BorderLayout());
+		return queryPanel;
+	}
 
-        JComponent ontologySelectPanel = createOntologySelectBox();
-        JComponent searchPanel = createSearchPanel();
+	private JComponent createSearchPanel() {
+		JPanel searchPanel = new JPanel(new BorderLayout());
+		JPanel searchBoxHolder = new JPanel(new BorderLayout());
 
-        queryPanel.add(ontologySelectPanel, BorderLayout.NORTH);
-        queryPanel.add(searchPanel, BorderLayout.SOUTH);
+		searchBox = new JTextField();
 
-        return queryPanel;
-    }
+		searchBoxHolder.add(searchBox, BorderLayout.NORTH);
 
-    private JComponent createSearchPanel() {
-        JPanel searchPanel = new JPanel(new BorderLayout());
-        JPanel searchBoxHolder = new JPanel(new BorderLayout());
+		executeButton = new JButton("Search");
 
-        searchBox = new JTextField();
+		AdditionalExecuteListener ael = new AdditionalExecuteListener();
+		executeButton.addActionListener(ael);
+		searchBox.addActionListener(ael);
 
-        searchBoxHolder.add(searchBox, BorderLayout.NORTH);
+		JPanel executeButtonHolder = new JPanel(new BorderLayout());
+		;
+		executeButtonHolder.add(executeButton, BorderLayout.WEST);
 
-        executeButton = new JButton("Search");
+		JPanel searchHolder = new JPanel(new BorderLayout());
 
-        AdditionalExecuteListener ael = new AdditionalExecuteListener();
-        executeButton.addActionListener(ael);
-        searchBox.addActionListener(ael);
+		searchHolder.add(searchBoxHolder, BorderLayout.NORTH);
+		searchHolder.add(executeButtonHolder, BorderLayout.WEST);
 
-        JPanel executeButtonHolder = new JPanel(new BorderLayout());;
-        executeButtonHolder.add(executeButton, BorderLayout.WEST);
+		searchPanel.add(searchHolder, BorderLayout.NORTH);
 
-        JPanel searchHolder = new JPanel(new BorderLayout());
+		searchPanel.setBorder(BorderFactory.createLineBorder(Color.LIGHT_GRAY));
 
-        searchHolder.add(searchBoxHolder, BorderLayout.NORTH);
-        searchHolder.add(executeButtonHolder, BorderLayout.WEST);
+		JComponent optionsBox = createOptionsBox();
+		searchPanel.add(optionsBox, BorderLayout.SOUTH);
 
-        searchPanel.add(searchHolder, BorderLayout.NORTH);
-
-        searchPanel.setBorder(BorderFactory.createLineBorder(Color.LIGHT_GRAY));
-
-        JComponent optionsBox = createOptionsBox();
-        searchPanel.add(optionsBox, BorderLayout.SOUTH);
-
-        searchPanel.setBorder(BorderFactory.createCompoundBorder(BorderFactory
-                .createTitledBorder(
-                        BorderFactory.createLineBorder(Color.LIGHT_GRAY),
-                        "Query"), BorderFactory.createEmptyBorder(3, 3,
-                3, 3)));
-
-        return searchPanel;
-    }
-
-    private JComponent createResultsPanel() {
-        JComponent resultsPanel = new JPanel(new BorderLayout(10, 10));
-        resultsPanel.setBorder(BorderFactory.createCompoundBorder(BorderFactory
-                .createTitledBorder(
-                        BorderFactory.createLineBorder(Color.LIGHT_GRAY),
-                        "Query Results"), BorderFactory.createEmptyBorder(3, 3,
-                3, 3)));
-        Object[][] InitResultData = {};
-        resultTable = new JTable(InitResultData, columnNames);
-        resultTable.setFillsViewportHeight(true);
-        resultTable.setModel(tableModel);
-        resultTable.setRowSelectionAllowed(true);
-        resultTable.setColumnSelectionAllowed(false);
-        resultTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        resultTable.setTransferHandler(new FromTransferHandler());
-
-        resultTable.setDragEnabled(true);
-        scrollPane = new JScrollPane(resultTable);
-        resultsPanel.add(scrollPane);
-
-        return resultsPanel;
-    }
-
-
-
-    private JComponent createOntologySelectBox() {
-        JComponent ontSelectPanel = new JPanel(new BorderLayout());
-
-        
-        this.ontologySelectBox = new JComboBox(ddla.getNames());
-
-        /* - Joseph 2017 - removing glazed lists because of maven problems
-        this.ontologySelectBox.setEditable(true);
-        AutoCompleteSupport<String> support = AutoCompleteSupport.install(
-                this.ontologySelectBox, GlazedLists.eventListOf(ddla.getNames()));
-        support.setStrict(true);
-        */
-        
-        JButton loadFromFileButton = new JButton("Load From File");
-        JButton loadFromURLButton = new JButton("Load From URL");
-        JButton selectFromListButton = new JButton("Select from list");
-        
-        LoadFromFileListener lffl = new LoadFromFileListener();
-        loadFromFileButton.addActionListener(lffl);
-        
-        LoadFromURLListener lful = new LoadFromURLListener();
-        loadFromURLButton.addActionListener(lful);
-
-        SelectFromListListener sfll = new SelectFromListListener();
-        selectFromListButton.addActionListener(sfll);
-
-        
-        JComponent ontSelectBoxHolder = new JPanel(new BorderLayout());
-        
-        ontSelectBoxHolder.setBorder(BorderFactory.createCompoundBorder(BorderFactory
-                .createTitledBorder(
-                        BorderFactory.createLineBorder(Color.LIGHT_GRAY),
-                        "Please choose ontology"), BorderFactory
-                .createEmptyBorder(3, 3, 3, 3)));
-
-        JPanel buttonHolder = new JPanel();
-        JPanel thirdButtonHolder = new JPanel();
-        buttonHolder.add(loadFromURLButton, BorderLayout.WEST);
-        buttonHolder.add(loadFromFileButton, BorderLayout.EAST);
-        thirdButtonHolder.add(buttonHolder, BorderLayout.WEST);
-        thirdButtonHolder.add(selectFromListButton, BorderLayout.EAST);
-        
-        ontSelectBoxHolder.add(thirdButtonHolder, BorderLayout.WEST);
-        ontSelectPanel.add(ontSelectBoxHolder, BorderLayout.NORTH);
-
-        this.currentOntologyBox = new JTextField();
-        this.currentOntologyBox.setEditable(false);
-
-        currentOntologyBox.setBorder(BorderFactory.createCompoundBorder(BorderFactory
-                .createTitledBorder(
-                        BorderFactory.createLineBorder(Color.LIGHT_GRAY),
-                        "Ontology Location"), BorderFactory
-                .createEmptyBorder(3, 3, 3, 3)));
-
-
-        ontSelectPanel.add(this.currentOntologyBox, BorderLayout.SOUTH);
-
-        return ontSelectPanel;
-    }
-
-    private JComponent createOptionsBox() {
-        JPanel optionsPanel = new JPanel();
-        optionsPanel.setLayout(new BoxLayout(optionsPanel, BoxLayout.X_AXIS));
-
-        Box searchByBox = new Box(BoxLayout.X_AXIS);
-        searchByBox.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createLineBorder(Color.LIGHT_GRAY),
-                "Search by"));
-
-        Box searchBox = new Box(BoxLayout.X_AXIS);
-        searchBox.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createLineBorder(Color.LIGHT_GRAY),
-                "Entity Type"));
-
-        clsCheckBox = new JCheckBox(
-                new AbstractAction("Class") {
-                    /**
-                     *
-                     */
-                    private static final long serialVersionUID = 1L;
-
-                    public void actionPerformed(ActionEvent e) {
-                        if(clsCheckBox.isSelected()){
-                            saoi.setSearchClassesFlag(true);
-                        } else {
-                            saoi.setSearchClassesFlag(false);
-                        }
-                    }
-                });
-
-        objPropCheckBox = new JCheckBox(
-                new AbstractAction("Object Property") {
-                    /**
-                     *
-                     */
-                    private static final long serialVersionUID = 1L;
-
-                    public void actionPerformed(ActionEvent e) {
-                        if(objPropCheckBox.isSelected()){
-                            saoi.setSearchObjectPropertiesFlag(true);
-                        } else {
-                            saoi.setSearchObjectPropertiesFlag(false);
-                        }
-                    }
-                });
-
-        //setting the class entity type as the default type to search for
-        clsCheckBox.setSelected(true);
-
-        searchBox.add(clsCheckBox);
-        searchBox.add(Box.createHorizontalStrut(1));
-
-        searchBox.add(objPropCheckBox);
-        searchBox.add(Box.createHorizontalStrut(1));
-
-        showSearchLabelCheckBox = new JCheckBox(
-                new AbstractAction("Label") {
-                    /**
-                     *
-                     */
-                    private static final long serialVersionUID = 1L;
-
-                    public void actionPerformed(ActionEvent e) {
-                        if(showSearchLabelCheckBox.isSelected()){
-                            saoi.setSearchByLabelFlag(true);
-                        } else {
-                            saoi.setSearchByLabelFlag(false);
-                        }
-                    }
-                });
-
-        //setting label checkbox as selected by default
-        showSearchLabelCheckBox.setSelected(true);
-
-        searchByBox.add(showSearchLabelCheckBox);
-        searchByBox.add(Box.createHorizontalStrut(1));
-
-        showSearchDefinitionCheckBox = new JCheckBox(
-                new AbstractAction("Definition") {
-                    /**
-                     *
-                     */
-                    private static final long serialVersionUID = 1L;
-
-                    public void actionPerformed(ActionEvent e) {
-                        if(showSearchDefinitionCheckBox.isSelected()){
-                            saoi.setSearchByDefinitionFlag(false);
-                        } else {
-                            saoi.setSearchByDefinitionFlag(false);
-                        }
-                    }
-                });
-
-        searchByBox.add(showSearchDefinitionCheckBox);
-        searchByBox.add(Box.createHorizontalStrut(1));
-
-        showSearchCommentCheckBox = new JCheckBox(
-                new AbstractAction("Comment") {
-
-                    /**
-                     *
-                     */
-                    private static final long serialVersionUID = 1L;
-
-                    public void actionPerformed(ActionEvent e) {
-                        if(showSearchCommentCheckBox.isSelected()){
-                            saoi.setSearchByCommentFlag(true);
-                        } else {
-                            saoi.setSearchByCommentFlag(false);
-                        }
-
-                    }
-                });
-
-        //setting comment checkbox as selected by default
-        showSearchCommentCheckBox.setSelected(true);
-
-        searchByBox.add(showSearchCommentCheckBox);
-        searchByBox.add(Box.createHorizontalStrut(1));
-
-        optionsPanel.add(searchBox);
-        optionsPanel.add(searchByBox);
-
-        optionsPanel.setBorder(BorderFactory.createCompoundBorder(BorderFactory
-                .createTitledBorder(
-                        BorderFactory.createLineBorder(Color.LIGHT_GRAY),
-                        "Query Options"), BorderFactory.createEmptyBorder(3, 3,
-                3, 3)));
-
-        return optionsPanel;
-    }
-
-    protected void disposeOWLView() {
-        getOWLModelManager().removeListener(listener);
-    }
-
-
-
-
-    private class AdditionalExecuteListener implements ActionListener {
-
-
-        public void actionPerformed(ActionEvent ee) {
-
-            if(clsCheckBox.isSelected() || objPropCheckBox.isSelected()){
-
-                query = searchBox.getText();
-                saoi.setQuery(query);
-                
-                //URL takes precidence over file.  If both file and URL is null, an error is thrown during search
-                saoi.setUrl(ontologyURL);
-                saoi.setFile(ontoFile);
-                
-
-                try {
-                    saoi.buildResultTable(columnNames, tableModel, resultTable);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-
-            }
-        }
-    }
-    
-    private class LoadFromFileListener implements ActionListener {
+		searchPanel.setBorder(BorderFactory.createCompoundBorder(
+				BorderFactory.createTitledBorder(BorderFactory.createLineBorder(Color.LIGHT_GRAY), "Query"),
+				BorderFactory.createEmptyBorder(3, 3, 3, 3)));
+
+		return searchPanel;
+	}
+
+	private JComponent createResultsPanel() {
+		JComponent resultsPanel = new JPanel(new BorderLayout(10, 10));
+		resultsPanel.setBorder(BorderFactory.createCompoundBorder(
+				BorderFactory.createTitledBorder(BorderFactory.createLineBorder(Color.LIGHT_GRAY), "Query Results"),
+				BorderFactory.createEmptyBorder(3, 3, 3, 3)));
+		Object[][] InitResultData = {};
+		resultTable = new JTable(InitResultData, columnNames);
+		resultTable.setFillsViewportHeight(true);
+		resultTable.setModel(tableModel);
+		resultTable.setRowSelectionAllowed(true);
+		resultTable.setColumnSelectionAllowed(false);
+		resultTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+		resultTable.setTransferHandler(new FromTransferHandler());
+
+		resultTable.setDragEnabled(true);
+		scrollPane = new JScrollPane(resultTable);
+		resultsPanel.add(scrollPane);
+
+		return resultsPanel;
+	}
+
+	private JComponent createOntologySelectBox() {
+		JComponent ontSelectPanel = new JPanel(new BorderLayout());
+
+		this.ontologySelectBox = new JComboBox(ddla.getNames());
+
+		/*
+		 * - Joseph 2017 - removing glazed lists because of maven problems
+		 * this.ontologySelectBox.setEditable(true); AutoCompleteSupport<String> support
+		 * = AutoCompleteSupport.install( this.ontologySelectBox,
+		 * GlazedLists.eventListOf(ddla.getNames())); support.setStrict(true);
+		 */
+
+		JButton loadFromFileButton = new JButton("Load From File");
+		JButton loadFromURLButton = new JButton("Load From URL");
+		JButton selectFromListButton = new JButton("Select from list");
+
+		LoadFromFileListener lffl = new LoadFromFileListener();
+		loadFromFileButton.addActionListener(lffl);
+
+		LoadFromURLListener lful = new LoadFromURLListener();
+		loadFromURLButton.addActionListener(lful);
+
+		SelectFromListListener sfll = new SelectFromListListener();
+		selectFromListButton.addActionListener(sfll);
+
+		JComponent ontSelectBoxHolder = new JPanel(new BorderLayout());
+
+		ontSelectBoxHolder.setBorder(BorderFactory.createCompoundBorder(BorderFactory
+				.createTitledBorder(BorderFactory.createLineBorder(Color.LIGHT_GRAY), "Please choose ontology"),
+				BorderFactory.createEmptyBorder(3, 3, 3, 3)));
+
+		JPanel buttonHolder = new JPanel();
+		JPanel thirdButtonHolder = new JPanel();
+		buttonHolder.add(loadFromURLButton, BorderLayout.WEST);
+		buttonHolder.add(loadFromFileButton, BorderLayout.EAST);
+		thirdButtonHolder.add(buttonHolder, BorderLayout.WEST);
+		thirdButtonHolder.add(selectFromListButton, BorderLayout.EAST);
+
+		ontSelectBoxHolder.add(thirdButtonHolder, BorderLayout.WEST);
+		ontSelectPanel.add(ontSelectBoxHolder, BorderLayout.NORTH);
+
+		this.currentOntologyBox = new JTextField();
+		this.currentOntologyBox.setEditable(false);
+
+		currentOntologyBox.setBorder(BorderFactory.createCompoundBorder(
+				BorderFactory.createTitledBorder(BorderFactory.createLineBorder(Color.LIGHT_GRAY), "Ontology Location"),
+				BorderFactory.createEmptyBorder(3, 3, 3, 3)));
+
+		ontSelectPanel.add(this.currentOntologyBox, BorderLayout.SOUTH);
+
+		return ontSelectPanel;
+	}
+
+	private JComponent createOptionsBox() {
+		JPanel optionsPanel = new JPanel();
+		optionsPanel.setLayout(new BoxLayout(optionsPanel, BoxLayout.X_AXIS));
+
+		Box searchByBox = new Box(BoxLayout.X_AXIS);
+		searchByBox.setBorder(BorderFactory.createTitledBorder(BorderFactory.createLineBorder(Color.LIGHT_GRAY),
+				"Search by RDFS Annotations"));
+
+		Box searchBox = new Box(BoxLayout.X_AXIS);
+		searchBox.setBorder(
+				BorderFactory.createTitledBorder(BorderFactory.createLineBorder(Color.LIGHT_GRAY), "Entity Type"));
+
+		clsCheckBox = new JCheckBox(new AbstractAction("Class") {
+			/**
+			 *
+			 */
+			private static final long serialVersionUID = 1L;
+
+			public void actionPerformed(ActionEvent e) {
+				if (clsCheckBox.isSelected()) {
+					saoi.setSearchClassesFlag(true);
+				} else {
+					saoi.setSearchClassesFlag(false);
+				}
+			}
+		});
+
+		objPropCheckBox = new JCheckBox(new AbstractAction("Object Property") {
+			/**
+			 *
+			 */
+			private static final long serialVersionUID = 1L;
+
+			public void actionPerformed(ActionEvent e) {
+				if (objPropCheckBox.isSelected()) {
+					saoi.setSearchObjectPropertiesFlag(true);
+				} else {
+					saoi.setSearchObjectPropertiesFlag(false);
+				}
+			}
+		});
+
+		// setting the class entity type as the default type to search for
+		clsCheckBox.setSelected(true);
+
+		searchBox.add(clsCheckBox);
+		searchBox.add(Box.createHorizontalStrut(1));
+
+		searchBox.add(objPropCheckBox);
+		searchBox.add(Box.createHorizontalStrut(1));
+
+		showSearchLabelCheckBox = new JCheckBox(new AbstractAction("Label") {
+			/**
+			 *
+			 */
+			private static final long serialVersionUID = 1L;
+
+			public void actionPerformed(ActionEvent e) {
+				if (showSearchLabelCheckBox.isSelected()) {
+					saoi.setSearchByLabelFlag(true);
+				} else {
+					saoi.setSearchByLabelFlag(false);
+				}
+			}
+		});
+
+		// setting label checkbox as selected by default
+		showSearchLabelCheckBox.setSelected(true);
+
+		searchByBox.add(showSearchLabelCheckBox);
+		searchByBox.add(Box.createHorizontalStrut(1));
+
+		showSearchDefinitionCheckBox = new JCheckBox(new AbstractAction("Definition") {
+			/**
+			 *
+			 */
+			private static final long serialVersionUID = 1L;
+
+			public void actionPerformed(ActionEvent e) {
+
+				if (showSearchDefinitionCheckBox.isSelected()) {
+					// Correct search by definition problem -> change false to true
+					saoi.setSearchByDefinitionFlag(true);
+				} else {
+					saoi.setSearchByDefinitionFlag(false);
+				}
+			}
+		});
+
+		searchByBox.add(showSearchDefinitionCheckBox);
+		searchByBox.add(Box.createHorizontalStrut(1));
+
+		showSearchCommentCheckBox = new JCheckBox(new AbstractAction("Comment") {
+
+			/**
+			 *
+			 */
+			private static final long serialVersionUID = 1L;
+
+			public void actionPerformed(ActionEvent e) {
+				if (showSearchCommentCheckBox.isSelected()) {
+					saoi.setSearchByCommentFlag(true);
+				} else {
+					saoi.setSearchByCommentFlag(false);
+				}
+
+			}
+		});
+
+		// setting comment checkbox as selected by default
+		showSearchCommentCheckBox.setSelected(true);
+
+		searchByBox.add(showSearchCommentCheckBox);
+		searchByBox.add(Box.createHorizontalStrut(1));
+		
+		/**
+		 * Add SKOS Annotations check boxes
+		 * 
+		 * @author Zakariae Aloulen
+		 */
+
+		Box searchBySKOSBox = new Box(BoxLayout.X_AXIS);
+		searchBySKOSBox.setBorder(BorderFactory.createTitledBorder(BorderFactory.createLineBorder(Color.LIGHT_GRAY),
+				"Search by SKOS Annotations"));
+
+		showSearchLabelSKOSCheckBox = new JCheckBox(new AbstractAction("Label") {
+			/**
+			 *
+			 */
+			private static final long serialVersionUID = 1L;
+
+			public void actionPerformed(ActionEvent e) {
+				if (showSearchLabelSKOSCheckBox.isSelected()) {
+					saoi.setSearchBySKOSLabelFlag(true);
+				} else {
+					saoi.setSearchBySKOSLabelFlag(false);
+				}
+			}
+		});
+
+		searchBySKOSBox.add(showSearchLabelSKOSCheckBox);
+		searchBySKOSBox.add(Box.createHorizontalStrut(1));
+
+		showSearchSKOSDefinitionCheckBox = new JCheckBox(new AbstractAction("Definition") {
+			/**
+			 *
+			 */
+			private static final long serialVersionUID = 1L;
+
+			public void actionPerformed(ActionEvent e) {
+
+				if (showSearchSKOSDefinitionCheckBox.isSelected()) {
+					saoi.setSearchBySKOSDefinitionFlag(true);
+				} else {
+					saoi.setSearchBySKOSDefinitionFlag(false);
+				}
+			}
+		});
+
+		searchBySKOSBox.add(showSearchSKOSDefinitionCheckBox);
+		searchBySKOSBox.add(Box.createHorizontalStrut(1));
+
+		showSearchSKOSAltLabelsCheckBox = new JCheckBox(new AbstractAction("Alternative Labels") {
+
+			/**
+			 *
+			 */
+			private static final long serialVersionUID = 1L;
+
+			public void actionPerformed(ActionEvent e) {
+				if (showSearchSKOSAltLabelsCheckBox.isSelected()) {
+					saoi.setSearchBySKOSAltLabelsFlag(true);
+				} else {
+					saoi.setSearchBySKOSAltLabelsFlag(false);
+				}
+
+			}
+		});
+
+		searchBySKOSBox.add(showSearchSKOSAltLabelsCheckBox);
+		searchBySKOSBox.add(Box.createHorizontalStrut(1));
+
+		optionsPanel.add(searchBox);
+		optionsPanel.add(searchByBox);
+		optionsPanel.add(searchBySKOSBox);
+
+		optionsPanel.setBorder(BorderFactory.createCompoundBorder(
+				BorderFactory.createTitledBorder(BorderFactory.createLineBorder(Color.LIGHT_GRAY), "Query Options"),
+				BorderFactory.createEmptyBorder(3, 3, 3, 3)));
+
+		return optionsPanel;
+	}
+
+	protected void disposeOWLView() {
+		getOWLModelManager().removeListener(listener);
+	}
+
+	private class AdditionalExecuteListener implements ActionListener {
+
+		public void actionPerformed(ActionEvent ee) {
+
+			if (clsCheckBox.isSelected() || objPropCheckBox.isSelected()) {
+
+				query = searchBox.getText();
+				saoi.setQuery(query);
+
+				// URL takes precidence over file. If both file and URL is null, an error is
+				// thrown during search
+				saoi.setUrl(ontologyURL);
+				saoi.setFile(ontoFile);
+
+				try {
+					saoi.buildResultTable(columnNames, tableModel, resultTable);
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+
+			}
+		}
+	}
+
+	private class LoadFromFileListener implements ActionListener {
 
 		@Override
 		public void actionPerformed(ActionEvent e) {
-			
+
 			final JFileChooser fc = new JFileChooser();
 			int returnVal = fc.showOpenDialog(currentOntologyBox);
-			
-			if(returnVal == JFileChooser.APPROVE_OPTION){
+
+			if (returnVal == JFileChooser.APPROVE_OPTION) {
 				ontoFile = fc.getSelectedFile();
 				ontologyURL = null;
-				
+
 				currentOntologyBox.setText(ontoFile.getAbsolutePath());
-			} 
+			}
 		}
-    	
-    }
-    
-    private class LoadFromURLListener implements ActionListener {
+
+	}
+
+	private class LoadFromURLListener implements ActionListener {
 
 		@Override
 		public void actionPerformed(ActionEvent e) {
-			String url = (String) JOptionPane.showInputDialog(currentOntologyBox,
-					"Ontology URL: ",
-					"Open Ontology by URL",
-					JOptionPane.PLAIN_MESSAGE,
-					null,
-					null,
-					null);
-				
-			if(url != null && !url.equals("")){
+			String url = (String) JOptionPane.showInputDialog(currentOntologyBox, "Ontology URL: ",
+					"Open Ontology by URL", JOptionPane.PLAIN_MESSAGE, null, null, null);
+
+			if (url != null && !url.equals("")) {
 				ontologyURL = url;
 				ontoFile = null;
-				
-		        currentOntologyBox.setText(ontologyURL);
+
+				currentOntologyBox.setText(ontologyURL);
 
 			}
-			
+
 		}
-    	
-    }
-    
-    private class SelectFromListListener implements ActionListener {
+
+	}
+
+	private class SelectFromListListener implements ActionListener {
 
 		@Override
 		public void actionPerformed(ActionEvent e) {
-			int returnVal = JOptionPane.showOptionDialog(currentOntologyBox, ontologySelectBox, "Choose from the list below.", JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
-			
-			if(returnVal == JOptionPane.OK_OPTION){
+			int returnVal = JOptionPane.showOptionDialog(currentOntologyBox, ontologySelectBox,
+					"Choose from the list below.", JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null,
+					null);
+
+			if (returnVal == JOptionPane.OK_OPTION) {
 				String selected = (String) ontologySelectBox.getSelectedItem();
-				
-		        ontologyURL = ddla.getLink(selected);
-		        ontoFile = null;
-		        
-		        currentOntologyBox.setText(ontologyURL);
+
+				ontologyURL = ddla.getLink(selected);
+				ontoFile = null;
+
+				currentOntologyBox.setText(ontologyURL);
 
 			}
-			
+
 		}
-    	
-    }
 
+	}
 
+	class FromTransferHandler extends TransferHandler {
+		/**
+		 *
+		 */
+		private static final long serialVersionUID = 1L;
 
+		public int getSourceActions(JComponent comp) {
+			return COPY;
+		}
 
-    class FromTransferHandler extends TransferHandler {
-        /**
-         *
-         */
-        private static final long serialVersionUID = 1L;
+		private int index = 0;
 
-        public int getSourceActions(JComponent comp) {
-            return COPY;
-        }
+		public Transferable createTransferable(JComponent comp) {
+			index = resultTable.getSelectedRow();
+			resultList = getSearcher().getResults();
+			SearchResult transferData = resultList.get(index);
 
-        private int index = 0;
+			String ontologyLabel = (String) ontologySelectBox.getSelectedItem();
+			String ontologyURL = ddla.getLink(ontologyLabel);
 
-        public Transferable createTransferable(JComponent comp) {
-            index = resultTable.getSelectedRow();
-            resultList = getSearcher().getResults();
-            SearchResult transferData = resultList.get(index);
+			if (transferData.getType().equals("Class")) {
+				ClassSearchResult classTransferData = (ClassSearchResult) transferData;
 
-            String ontologyLabel = (String) ontologySelectBox.getSelectedItem();
-            String ontologyURL = ddla.getLink(ontologyLabel);
+				return new OWLClassTransferable((OWLClass) classTransferData.getOWLEntity(),
+						classTransferData.getOntology(), ontologyURL);
 
-            if(transferData.getType().equals("Class")){
-                ClassSearchResult classTransferData = (ClassSearchResult) transferData;
+			} else if (transferData.getType().equals("Object Property")) {
+				ObjectPropertySearchResult objectPropertyTransferData = (ObjectPropertySearchResult) transferData;
 
-                return new OWLClassTransferable((OWLClass) classTransferData.getOWLEntity(), classTransferData.getOntology(), ontologyURL);
+				return new OWLObjectPropertyTransferable((OWLObjectProperty) objectPropertyTransferData.getOWLEntity(),
+						objectPropertyTransferData.getOntology(), ontologyURL);
+			}
 
-            } else if(transferData.getType().equals("Object Property")){
-                ObjectPropertySearchResult objectPropertyTransferData = (ObjectPropertySearchResult) transferData;
+			return null;
+		}
 
-                return new OWLObjectPropertyTransferable((OWLObjectProperty) objectPropertyTransferData.getOWLEntity(), objectPropertyTransferData.getOntology(), ontologyURL);
-            }
+		public void exportDone(JComponent comp, Transferable trans, int action) {
 
-            return null;
-        }
+			if (action != MOVE) {
+				return;
+			}
+		}
 
-        public void exportDone(JComponent comp, Transferable trans, int action) {
-
-            if (action != MOVE) {
-                return;
-            }
-        }
-
-
-    }
-
+	}
 
 }

--- a/src/main/java/edu/uams/dbmi/protege/plugin/mireot/view/DatatypePropertyView.java
+++ b/src/main/java/edu/uams/dbmi/protege/plugin/mireot/view/DatatypePropertyView.java
@@ -29,15 +29,15 @@ import org.semanticweb.owlapi.model.OWLAnnotation;
 import org.semanticweb.owlapi.model.OWLAnnotationProperty;
 import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.semanticweb.owlapi.model.OWLDataProperty;
+import org.semanticweb.owlapi.model.OWLDataPropertyExpression;
 import org.semanticweb.owlapi.model.OWLObject;
-import org.semanticweb.owlapi.model.OWLObjectProperty;
-import org.semanticweb.owlapi.model.OWLObjectPropertyExpression;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyChange;
 import org.semanticweb.owlapi.model.OWLSubPropertyAxiom;
 import org.semanticweb.owlapi.model.RemoveAxiom;
 
-import edu.uams.dbmi.protege.plugin.mireot.search.transferable.OWLObjectPropertyTransferable.OWLObjectPropertyMessage;
+import edu.uams.dbmi.protege.plugin.mireot.search.transferable.OWLDatatypePropertyTransferable.OWLDatatypePropertyMessage;
 import org.semanticweb.owlapi.search.EntitySearcher;
 
 /**
@@ -45,10 +45,10 @@ import org.semanticweb.owlapi.search.EntitySearcher;
  * 
  * @author Josh Hanna
  */
-public class ObjectPropertyView extends AbstractOWLPropertyHierarchyViewComponent<OWLObjectProperty> 
+public class DatatypePropertyView extends AbstractOWLPropertyHierarchyViewComponent<OWLDataProperty> 
 implements DropTargetListener{
 
-	DataFlavor dataFlavor = new DataFlavor(OWLObjectProperty.class, OWLObjectProperty.class.getSimpleName());
+	DataFlavor dataFlavor = new DataFlavor(OWLDataProperty.class, OWLDataProperty.class.getSimpleName());
 
 	/**
 	 * 
@@ -63,41 +63,36 @@ implements DropTargetListener{
 	}
 
 
-	protected boolean isOWLObjectPropertyView() {
+	protected boolean isOWLDatatypePropertyView() {
 		return true;
 	}
 
-	protected OWLObjectHierarchyProvider<OWLObjectProperty> getHierarchyProvider() {
-		return getOWLModelManager().getOWLHierarchyManager().getOWLObjectPropertyHierarchyProvider();
-	}
 
-	protected Optional<OWLObjectHierarchyProvider<OWLObjectProperty>> getInferredHierarchyProvider() {
-		return Optional.of(getOWLModelManager().getOWLHierarchyManager().
-				getInferredOWLObjectPropertyHierarchyProvider());
-	}
 
-	protected OWLSubPropertyAxiom<?> getSubPropertyAxiom(OWLObjectProperty child, OWLObjectProperty parent) {
-		return getOWLDataFactory().getOWLSubObjectPropertyOfAxiom(child, parent);
+
+
+	protected OWLSubPropertyAxiom<?> getSubPropertyAxiom(OWLDataProperty child, OWLDataProperty parent) {
+		return getOWLDataFactory().getOWLSubDataPropertyOfAxiom(child, parent);
 	}
 
 	protected boolean canAcceptDrop(Object child, Object parent) {
-		return child instanceof OWLObjectProperty;
+		return child instanceof OWLDataProperty;
 	}
 
-	protected OWLEntityCreationSet<OWLObjectProperty> createProperty() {
-		return getOWLWorkspace().createOWLObjectProperty();
+	protected OWLEntityCreationSet<OWLDataProperty> createProperty() {
+		return getOWLWorkspace().createOWLDataProperty();
 	}
 
 	protected Icon getSubIcon() {
-		return OWLIcons.getIcon("property.object.addsub.png");
+		return OWLIcons.getIcon("property.data.addsub.png");
 	}
 
 	protected Icon getSibIcon() {
-		return OWLIcons.getIcon("property.object.addsib.png");
+		return OWLIcons.getIcon("property.data.addsib.png");
 	}
 
 	protected Icon getDeleteIcon() {
-		return OWLIcons.getIcon("property.object.delete.png");
+		return OWLIcons.getIcon("property.data.delete.png");
 	}
 
 	@Override
@@ -124,7 +119,7 @@ implements DropTargetListener{
 		// gets the cursor point
 		Point pt = dtde.getLocation();
 
-		OWLObjectTree<OWLObjectProperty> tr = getTree();
+		OWLObjectTree<OWLDataProperty> tr = getTree();
 
 		// finds the current path to the cursor in the tree
 		TreePath parentPath = tr.getClosestPathForLocation(pt.x, pt.y);
@@ -137,21 +132,21 @@ implements DropTargetListener{
 		OWLObject ob = (OWLObject) n.getOWLObject();
 
 		// get all the object properties for the object
-		Set<OWLObjectProperty> objPropSet = ob.getObjectPropertiesInSignature();
+		Set<OWLDataProperty> dataPropSet = ob.getDataPropertiesInSignature();
 
 		// create an iterator for the set. the first element is the parent property
-		Iterator<OWLObjectProperty> it = objPropSet.iterator();
-		OWLObjectProperty origin = it.next();
+		Iterator<OWLDataProperty> it = dataPropSet.iterator();
+		OWLDataProperty origin = it.next();
 
 		// get the data being transferred by the drop
 		Transferable trans = dtde.getTransferable();
 
 		if(trans.isDataFlavorSupported(dataFlavor)){
 
-			OWLObjectPropertyMessage msg = null;
+			OWLDatatypePropertyMessage msg = null;
 
 			try {
-				msg = (OWLObjectPropertyMessage) trans.getTransferData(dataFlavor);
+				msg = (OWLDatatypePropertyMessage) trans.getTransferData(dataFlavor);
 			} catch (UnsupportedFlavorException e) {
 				e.printStackTrace();
 			} catch (IOException e) {
@@ -189,7 +184,7 @@ implements DropTargetListener{
 	}
 
 	@SuppressWarnings("unchecked")
-	private void handleLocalDrop(Transferable trans, OWLObjectProperty origin) {
+	private void handleLocalDrop(Transferable trans, OWLDataProperty origin) {
 
 		ArrayList<OWLObject> objects = null;
 		try {
@@ -204,11 +199,11 @@ implements DropTargetListener{
 
 		OWLOntology activeOnt = this.getOWLModelManager().getActiveOntology();
 
-		OWLObjectProperty objPropInTransit = null;
+		OWLDataProperty dataPropInTransit = null;
 
-		if(objects.get(0) instanceof OWLObjectProperty){
+		if(objects.get(0) instanceof OWLDataProperty){
 			// load in the additional class from the iri
-			objPropInTransit = (OWLObjectProperty) objects.get(0);
+			dataPropInTransit = (OWLDataProperty) objects.get(0);
 		} else {
 			return;
 		}
@@ -216,47 +211,47 @@ implements DropTargetListener{
 		// get the parent of the additional class. this is pointless for a
 		// non local drag but is needed to make sure the tree looks right
 		// otherwise
-		Set<OWLObjectPropertyExpression> sup = new HashSet<>(EntitySearcher.getSuperProperties(objPropInTransit, activeOnt));
-		Iterator<OWLObjectPropertyExpression> s = sup.iterator();
+		Set<OWLDataPropertyExpression> sup = new HashSet<>(EntitySearcher.getSuperProperties(dataPropInTransit, activeOnt));
+		Iterator<OWLDataPropertyExpression> s = sup.iterator();
 
 		// the first element in the superclass set is the parent (if this
 		// changes it will break the drag and drop for local)
 
-		OWLObjectPropertyExpression oc = null;
+		OWLDataPropertyExpression oc = null;
 
 		if (s.hasNext()) {
 			oc = s.next();
 		}
 
-		OWLObjectProperty fromParent = null;
+		OWLDataProperty fromParent = null;
 
 		if(oc != null){
-			fromParent = oc.asOWLObjectProperty();
+			fromParent = oc.asOWLDataProperty();
 		} 
 
 		// get the set of annotations for the additional class
-		Set<OWLAnnotation> anots = new HashSet<>(EntitySearcher.getAnnotations(objPropInTransit.getIRI(), activeOnt));
+		Set<OWLAnnotation> anots = new HashSet<>(EntitySearcher.getAnnotations(dataPropInTransit.getIRI(), activeOnt));
 
-		addObjectProperty(objPropInTransit, origin, anots);
+		addDatatypeProperty(dataPropInTransit, origin, anots);
 
-		removeParent(objPropInTransit, fromParent);
+		removeParent(dataPropInTransit, fromParent);
 
 	}
 
 
 
-	private void handleRemoteDrop(OWLObjectPropertyMessage msg, OWLObjectProperty active) {
+	private void handleRemoteDrop(OWLDatatypePropertyMessage msg, OWLDataProperty active) {
 		OWLAnnotationProperty importedFromProperty = getOWLDataFactory().getOWLAnnotationProperty(IRI.create("http://purl.obolibrary.org/obo/IAO_0000412"));
 		OWLAnnotationProperty label = getOWLDataFactory().getRDFSLabel();
 
-		OWLObjectProperty objProp = msg.getObjectProperty();
+		OWLDataProperty dtProp = msg.getDatatypeProperty();
 		OWLOntology ontology = msg.getOntology();
 
-		Set<OWLAnnotation> annotations = new HashSet<>(EntitySearcher.getAnnotations(objProp.getIRI(), ontology));
+		Set<OWLAnnotation> annotations = new HashSet<>(EntitySearcher.getAnnotations(dtProp.getIRI(), ontology));
 
 		//getting annotations from the imports, too
 		for(OWLOntology ont : ontology.getImports()){
-			annotations.addAll(EntitySearcher.getAnnotations(objProp.getIRI(), ont));
+			annotations.addAll(EntitySearcher.getAnnotations(dtProp.getIRI(), ont));
 		}
 
 		List<OWLOntologyChange> changes = new ArrayList<OWLOntologyChange>();
@@ -307,17 +302,17 @@ implements DropTargetListener{
 
 		getOWLModelManager().applyChanges(changes);
 		
-		addObjectProperty(objProp, active, annotations);
+		addDatatypeProperty(dtProp, active, annotations);
 	}
 
-	private void addObjectProperty(OWLObjectProperty child, OWLObjectProperty parent,
+	private void addDatatypeProperty(OWLDataProperty child, OWLDataProperty parent,
 			Set<OWLAnnotation> annotations) {
 
 		OWLDataFactory df = getOWLModelManager().getOWLDataFactory();
 
 
 		//can't move topObjectProperty
-		if (child.equals(getOWLModelManager().getOWLDataFactory().getOWLTopObjectProperty())) {
+		if (child.equals(getOWLModelManager().getOWLDataFactory().getOWLTopDataProperty())) {
 			return;
 		}
 
@@ -334,7 +329,7 @@ implements DropTargetListener{
 		changes.add(new AddAxiom(getOWLModelManager().getActiveOntology(), df.getOWLDeclarationAxiom(child)));
 
 		if (!df.getOWLThing().equals(parent)) {
-			changes.add(new AddAxiom(getOWLModelManager().getActiveOntology(), df.getOWLSubObjectPropertyOfAxiom(child, parent)));
+			changes.add(new AddAxiom(getOWLModelManager().getActiveOntology(), df.getOWLSubDataPropertyOfAxiom(child, parent)));
 		}
 
 		getOWLModelManager().applyChanges(changes);
@@ -342,7 +337,7 @@ implements DropTargetListener{
 
 	}
 
-	private void removeParent(OWLObjectProperty child, OWLObjectProperty parent) {
+	private void removeParent(OWLDataProperty child, OWLDataProperty parent) {
 
 		//pointless if either is null
 		if(parent == null || child == null){
@@ -353,12 +348,20 @@ implements DropTargetListener{
 
 		getOWLModelManager().applyChange(
 				new RemoveAxiom(getOWLModelManager().getActiveOntology(), 
-						df.getOWLSubObjectPropertyOfAxiom(child, parent)));
+						df.getOWLSubDataPropertyOfAxiom(child, parent)));
 	}
 
 	@Override
 	public void dropActionChanged(DropTargetDragEvent dtde) {
 		//do nothing
+	}
+	
+	protected Optional<OWLObjectHierarchyProvider<OWLDataProperty>> getInferredHierarchyProvider() {
+		 return Optional.empty();
+	}
+	
+	protected OWLObjectHierarchyProvider<OWLDataProperty> getHierarchyProvider() {
+		return getOWLModelManager().getOWLHierarchyManager().getOWLDataPropertyHierarchyProvider();
 	}
 
 }

--- a/src/main/resources/plugin.xml
+++ b/src/main/resources/plugin.xml
@@ -35,6 +35,23 @@
    		
    </extension>
    
+   
+      <extension
+   		id="DatatypePropertyView"
+   		point="org.protege.editor.core.application.ViewComponent">
+   		<label 
+   			value = "MIREOT Datatype Property Hierarchy">
+   		</label>
+   		<class 
+   			value="edu.uams.dbmi.protege.plugin.mireot.view.DatatypePropertyView">
+   		</class>
+   		<category 
+   			value ="@org.protege.datapropertycategory">
+   		</category>
+        <headerColor value="@org.protege.datapropertycolor"/>
+   		
+   </extension>
+   
    <extension
          id="AdditionalOntologyView"
          point="org.protege.editor.core.application.ViewComponent">

--- a/src/main/resources/viewconfig-MIREOTTab.xml
+++ b/src/main/resources/viewconfig-MIREOTTab.xml
@@ -12,7 +12,13 @@
                     <Property id="pluginId" value="protege.plugin.mireot.ObjectPropertyView"/>
                 </Component>
             </CNode>
+            <CNode>
+                <Component label="MIREOT Datatype Property Hierarchy">
+                    <Property id="pluginId" value="protege.plugin.mireot.DatatypePropertyView"/>
+                </Component>
+            </CNode>
         </HSNode>
+        
         <CNode>
             <Component label="MIREOT Additional Ontology View">
                 <Property id="pluginId" value="protege.plugin.mireot.AdditionalOntologyView"/>


### PR DESCRIPTION
Add search by data property support : 
- You can now search data properties in ontologies;
- Datatype properties TAB was added to MIREOT.

Correct the problem of drug & drop of object properties :
- ObjectPropertyView (lines : 295 & 297) -> change
ontology.getOntologyID().getVersionIRI() != null TO
ontology.getOntologyID().getVersionIRI().isPresent